### PR TITLE
Add LogTriage Detection Rules (free validated Sigma library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Resources are tailored as much as possible to the role of the detection engineer
 - [SOC Prime](https://socprime.com/) - Great collection of free and paid detection rules (requires registration).
 - [SnapAttack](https://snapattack.com/) - Collection of free and paid detection rules (requires registration).
 - [Clankerusecase](https://clankerusecase.com) - Open-source library of 7,800+ MITRE ATT&CK-mapped detections in Defender KQL, Sentinel KQL, Sigma, Splunk SPL, Datadog, Falcon & CloudWatch, generated from live threat-intel and schema-validated.
+- [LogTriage Detection Rules](https://logtriage.app/rules/) - Free Sigma rules, each validated against a real sample log (fires on malicious, silent on benign); mapped to log source + MITRE ATT&CK.
+
 
 ### Detection Logic
 - [Active Directory Detection Logic | Picus](https://www.picussecurity.com/hubfs/Threat%20Readiness%20-%20Active%20Directory%20Ebook%20-%20Q123/Picus-The-Complete-Active-Directory-Security-Handbook.pdf) - Handbook with active directory attack descriptions and detection recommendations.


### PR DESCRIPTION
Adds LogTriage's free detection-rule library to the Detection Rules section.

Disclosure: I built it. What's different from a generic rules link — every rule is validated against a real sample log in CI before publishing: it must fire on the known-malicious sample and stay silent on the benign one. Each rule maps to its log source + MITRE ATT&CK technique with false-positive notes.

Happy to adjust placement or wording. Thanks for maintaining this list!
